### PR TITLE
Remove special characters from string

### DIFF
--- a/services.json
+++ b/services.json
@@ -1672,7 +1672,7 @@
     "enquisite.com", "inboundwriter.com"
   ]}},
   {"INFOnline": {"https://www.infonline.de/": [
-    "infonline.de", "­ioam.­de", "ivwbox.de"
+    "infonline.de", "ioam.de", "ivwbox.de"
   ]}},
   {"InfoStars": {"http://infostars.ru/": ["hotlog.ru", "infostars.ru"]}},
   {"Inspectlet": {"http://www.inspectlet.com/": ["inspectlet.com"]}},


### PR DESCRIPTION
The string "­ioam.­de" had special unicode characters (U+002E) before the "i" and the "d".