### PR TITLE
Remove Adzerk from services.json

### DIFF
--- a/services.json
+++ b/services.json
@@ -239,7 +239,6 @@
   {"Adworx": {"http://adworx.at/": ["adworx.at", "adworx.be", "adworx.nl"]}},
   {"ADZ": {"http://www.adzcentral.com/": ["adzcentral.com"]}},
   {"adzly": {"http://www.adzly.com/": ["adzly.com"]}},
-  {"Adzerk": {"http://www.adzerk.com/": ["adzerk.com", "adzerk.net"]}},
   {"Aegis Group": {"http://www.aemedia.com/": [
     "aemedia.com", "bluestreak.com"
   ]}},


### PR DESCRIPTION
Adzerk has joined the Do Not Track coalition. More info: https://www.eff.org/press/releases/online-ad-company-adopts-new-do-not-track-standard-web-browsing
