### PR TITLE
Unblock non-tracking Wishabi domains

### DIFF
--- a/services.json
+++ b/services.json
@@ -5652,8 +5652,7 @@
       {
         "Wishabi": {
           "http://wishabi.com": [
-            "wishabi.com",
-            "wishabi.net"
+            "wishabi.com"
           ]
         }
       },


### PR DESCRIPTION
Wishabi provides hosted store ad services for many North American
retailers. All tracking/analytics activity occurs on the wishabi.com
domain, but static image assets served from the wishabi.net domain are
being blocked, causing loss of functionality when browsing weekly ads on
retailer sites.