### PR TITLE
Add StackPath / MaxCDN to the Content category

### DIFF
--- a/services.json
+++ b/services.json
@@ -7211,6 +7211,15 @@
         }
       },
       {
+        "StackPath": {
+          "https://www.stackpath.com/": [
+            "maxcdn.com",
+            "netdna-ssl.com",
+            "netdna-cdn.com"
+          ]
+        }
+      },
+      {
         "Superfish": {
           "http://www.superfish.com/": [
             "superfish.com"


### PR DESCRIPTION
Adds the MaxCDN content and tracking network (now owned by StackPath) to the Content category. 

Grounds for adding MaxCDN:
• Found to be one of the top ten trackers in data produced by "Online tracking: A 1-million-site measurement and analysis" https://webtransparency.cs.princeton.edu/webcensus
• Listed on https://whotracks.me/trackers/maxcdn.html

MaxCDN also appears in easylist's blocking rules