### PR TITLE
Move Rubicon Project to it's own entry

### DIFF
--- a/services.json
+++ b/services.json
@@ -2160,7 +2160,7 @@
       },
       {
         "Drawbridge": {
-          "http://http://drawbrid.ge/": [
+          "http://drawbrid.ge/": [
             "adsymptotic.com",
             "drawbrid.ge"
           ]

--- a/services.json
+++ b/services.json
@@ -2512,8 +2512,7 @@
             "foxonestop.com",
             "mobsmith.com",
             "myads.com",
-            "othersonline.com",
-            "rubiconproject.com"
+            "othersonline.com"
           ]
         }
       },
@@ -4657,6 +4656,13 @@
         "Rovion": {
           "http://www.rovion.com/": [
             "rovion.com"
+          ]
+        }
+      },
+      {
+        "Rubicon Project": {
+          "http://rubiconproject.com": [
+            "rubiconproject.com"
           ]
         }
       },


### PR DESCRIPTION
I noticed `rubiconproject.com` was associated with Fox One Stop Media, and I can't find any association to them in the real world--The Rubicon Project seems like it's own thing: https://rubiconproject.com/who-we-are/

