### PR TITLE
Remove newrelic from list of tracking software.

### DIFF
--- a/services.json
+++ b/services.json
@@ -8352,14 +8352,6 @@
         }
       },
       {
-        "New Relic": {
-          "http://newrelic.com/": [
-            "newrelic.com",
-            "nr-data.net"
-          ]
-        }
-      },
-      {
         "NewsRight": {
           "http://www.newsright.com/": [
             "apnewsregistry.com"


### PR DESCRIPTION
Hello!

New Relic is a performance monitoring company. As a company, they don't store personal information such as IP addresses.

This list specifically targets the Browser product. The JavaScript that runs in your browser will instrument things such as page loads and interaction timing.

These performance metrics will help site owners monitor the performance of their website and give them actionable feedback to tune their site for faster performance.

Here are some quotes from our [privacy policy](https://newrelic.com/termsandconditions/privacy).

> In general, Personal Data you submit to us is used either to respond to requests that you make, or to aid us in serving you better.

> We may share your Personal Data with third parties to provide technical support or to provide specific services, such as hosting of your applications, communicating with you via live chat software or payment processing for purchases.

> To request removal of your personal information from our blog or community forum, contact us at support@newrelic.com.