### PR TITLE
Correct blocking of Dynamic Yield tracker

### DIFF
--- a/services.json
+++ b/services.json
@@ -2215,13 +2215,6 @@
         }
       },
       {
-        "DynamicYield": {
-          "https://www.dynamicyield.com/": [
-            "dynamicyield.com"
-          ]
-        }
-      },
-      {
         "EQ Ads": {
           "http://www.eqads.com/": [
             "eqads.com"
@@ -7956,6 +7949,14 @@
         "DirectCORP": {
           "http://www.directcorp.de/": [
             "ipcounter.de"
+          ]
+        }
+      },
+      {
+        "DynamicYield": {
+          "https://www.dynamicyield.com/": [
+            "px.dynamicyield.com",
+            "px-eu.dynamicyield.com"
           ]
         }
       },


### PR DESCRIPTION
Dynamic Yield is a content serving and personalization platform. It does have a data collection (for personalization) and analytics (for reports) component, which only goes through px.dynamicyield.com .

Please block only the data collection and analytics scripts, without blocking the content serving.