### PR TITLE
Remove Intercom from entities.json and services.json

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -5767,14 +5767,6 @@
       "intentmedia.net"
     ]
   },
-  "Intercom": {
-    "properties": [
-      "intercom.io"
-    ],
-    "resources": [
-      "intercom.io"
-    ]
-  },
   "Intergi": {
     "properties": [
       "intergi.com"

--- a/services.json
+++ b/services.json
@@ -8764,13 +8764,6 @@
         }
       },
       {
-        "Intercom": {
-          "https://www.intercom.io/": [
-            "intercom.io"
-          ]
-        }
-      },
-      {
         "iPerceptions": {
           "http://www.iperceptions.com/": [
             "iperceptions.com"


### PR DESCRIPTION
Following the same process as shown in https://github.com/disconnectme/disconnect-tracking-protection/commit/2018397b3bc1561371cda0991bdb9f814f8551e7 - this removes Intercom from the list of domains in the `services.json` and `entities.json` files.