### PR TITLE
Remove Parse.ly as tracker

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -8085,14 +8085,6 @@
       "pardot.com"
     ]
   },
-  "Parse.ly": {
-    "properties": [
-      "parsely.com"
-    ],
-    "resources": [
-      "parsely.com"
-    ]
-  },
   "PayHit": {
     "properties": [
       "payhit.com"

--- a/services.json
+++ b/services.json
@@ -7759,13 +7759,6 @@
         }
       },
       {
-        "Parse.ly": {
-          "http://parsely.com/": [
-            "parsely.com"
-          ]
-        }
-      },
-      {
         "Peerius": {
           "http://www.peerius.com/": [
             "peerius.com"


### PR DESCRIPTION
Parse.ly does not fall within Disconnect's [definition of tracking](https://disconnect.me/trackerprotection). 

Disconnect states that "Tracking is the collection of data regarding a particular user's activity across multiple websites or applications that aren’t owned by the data collector" and "And the collection is across context, so it doesn’t apply in cases when there is solely a first-party relationship with the user, for example the site only collects and retains information on site visitors."

From [Parse.ly's website](https://www.parse.ly/help/integration/gdpr/): 

> We avoid storing extraneous data on visitors, only instrumenting sites with collection mechanisms that enhance our first-party reporting capabilities.
> 
> All the data that we collect automatically is de-identified. For example, our repeat visitor analytics is based on anonymous, randomized universally unique identifiers (aka UUIDs) that are stored on a per-site basis, and are not linked with any personal identities. We do make use of cookies and IP addresses, as described in our privacy policy and terms of service, but we restrict their use to merely recognizing unique browsers/devices, not as a way to link personal identity or other sensitive personal information.

It is not possible for Parse.ly to build a profile based on an individual's online activity that can be connected with a real name or other unique identifier. 