### PR TITLE
Please remove olark as a tracker

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -7925,14 +7925,6 @@
       "ohanaqb.com"
     ]
   },
-  "Olark": {
-    "properties": [
-      "olark.com"
-    ],
-    "resources": [
-      "olark.com"
-    ]
-  },
   "Omnicom Group": {
     "properties": [
       "accuenmedia.com",

--- a/services.json
+++ b/services.json
@@ -7976,13 +7976,6 @@
         }
       },
       {
-        "Olark": {
-          "http://www.olark.com/": [
-            "olark.com"
-          ]
-        }
-      },
-      {
         "Ooyala": {
           "http://www.ooyala.com/": [
             "oo4.com",


### PR DESCRIPTION
We've updated the Olark privacy policy with a commitment not to track people across properties not owned by Olark. The privacy policy can be seen here: https://www.olark.com/privacy-policy

The new language in question reads: "Olark’s embedded chat (and specifically the domains olark.com, static.olark.com, and assets.olark.com) does not collect, store, or share data regarding a particular user’s activity (including through the use of IP and unique user identifiers) across multiple websites, or applications that are not owned by Olark."