### PR TITLE
Shift Parse.ly API and websites to Content

### DIFF
--- a/services.json
+++ b/services.json
@@ -8252,6 +8252,15 @@
         }
       },
       {
+        "Parse.ly": {
+          "http://parsely.com/": [
+            "api.parsely.com",
+            "currents.parsely.com",
+            "dash.parsely.com"
+          ]
+        }
+      },
+      {
         "Peerius": {
           "http://www.peerius.com/": [
             "peerius.com"
@@ -9598,7 +9607,8 @@
       {
         "Parse.ly": {
           "http://parsely.com/": [
-            "parsely.com"
+            "config.parsely.com",
+            "pixel.parsely.com"
           ]
         }
       },


### PR DESCRIPTION
I have moved three Parse.ly subdomains to Content.

`dash.parsely.com` is our [Dashboard](https://dash.parsely.com/) for customers who use us to help measure content performance. 
`currents.parsely.com` is our [data visualization](https://currents.parsely.com/) tool which aggregates and anonymizes our network data.
`api.parsely.com` is used to serve first-party content powered by our recommendation engine. This is how [ArsTechnica](https://arstechnica.com/information-technology/2014/11/disconnects-new-app-pulls-the-plug-on-supercookies-other-tracking/) chooses stories in their "Related Content" field. We have many other customers who use our API and are punished by blocking the API endpoint. 

I've also specified the Parse.ly Analytics domains. I did not see a way to wildcard for all domains except Content domains. If I am provided guidance, I can modify the PR.

See related discussion: https://github.com/disconnectme/disconnect-tracking-protection/pull/78