### PR TITLE
Update entity list to reflect full set of properties and resources for Salesforce

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -9266,11 +9266,30 @@
   },
   "Salesforce.com": {
     "properties": [
-      "salesforce.com"
+      "documentforce.com",
+      "force.com",
+      "forcesslreports.com",
+      "forceusercontent.com",
+      "lightning.com",
+      "salesforce.com",
+      "salesforce-communities.com",
+      "salesforce-hub.com",
+      "salesforceliveagent.com",
+      "trailblazer.me",
+      "visualforce.com"
     ],
     "resources": [
+      "documentforce.com",
+      "force.com",
+      "forcesslreports.com",
+      "forceusercontent.com",
+      "lightning.com",
       "salesforce.com",
-      "salesforceliveagent.com"
+      "salesforce-communities.com",
+      "salesforce-hub.com",
+      "salesforceliveagent.com",
+      "trailblazer.me",
+      "visualforce.com"
     ]
   },
   "Salesintelligence": {


### PR DESCRIPTION
Update the entities.json list to reflect the full set of owned/operated web properties registered and operated by Salesforce.com, Inc.. This update helps prevent breakage when related properties such as force.com host content from salesforce.com or related subdomains.