### PR TITLE
Update entities.json to reflect full set of Mercadolibre/Mercadopago properties

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -7109,6 +7109,25 @@
   },
   "Mercadopago": {
     "properties": [
+      "mercadolibre.com",
+      "mercadolibre.com.ar",
+      "mercadolibre.com.bo",
+      "mercadolivre.com.br",
+      "mercadolibre.cl",
+      "mercadolibre.com.co",
+      "mercadolibre.co.cr",
+      "mercadolibre.com.do",
+      "mercadolibre.com.ec",
+      "mercadolibre.com.gt",
+      "mercadolibre.com.hn",
+      "mercadolibre.com.mx",
+      "mercadolibre.com.ni",
+      "mercadolibre.com.pa",
+      "mercadolibre.com.py",
+      "mercadolibre.com.pe",
+      "mercadolibre.com.sv",
+      "mercadolibre.com.uy",
+      "mercadolibre.com.ve",
       "mercadopago.com"
     ],
     "resources": [


### PR DESCRIPTION
Mercadopago appears to be a payment provider and is listed in services.json and owned/operated by `MercadoLibre Inc.`. Mercado Libre and it's associated domains is also owned/operated by `MercadoLibre Inc.`. This change updates entities.json to reflect that mercadolibre.com and associated geo-local variants are properties of "Mercadopago" which can load resources from mercadopago.com and are grouped together as they are part of the same entity/organization.