### PR TITLE
Add SpongePowered to Tracker List

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -9856,6 +9856,16 @@
       "spongecell.com"
     ]
   },
+  "SpongePowered": {
+    "properties": [
+      "spongemc.org",
+      "spongepowered.org",
+      "spongeproject.net"
+    ],
+    "resources": [
+      "analytics.spongeproject.net"
+    ]
+  },
   "SponsorAds": {
     "properties": [
       "sponsorads.de"

--- a/services.json
+++ b/services.json
@@ -9581,6 +9581,13 @@
         }
       },
       {
+        "SpongePowered": {
+          "https://www.spongepowered.org": [
+            "analytics.spongeproject.net"
+          ]
+        }
+      },
+      {
         "Sputnik.ru": {
           "http://sputnik.ru": [
             "sputnik.ru"


### PR DESCRIPTION
Sponge has recently [introduced tracking](https://github.com/SpongePowered/Ore/pull/904/commits/77b14fd76d928edd70d181fa9200092da3fd71fc) to their Ore plugin repository (https://github.com/SpongePowered/Ore/pull/904), which can be seen on their [staging instance of the site](https://ore.stage.spongemc.org/). I expect this to make it's way to their [main site](https://www.spongepowered.org/) shortly too.

They are running an instance of Matomo for tracking, located at analytics.spongeproject.net.

---

Additionally, I believe that this patch does what I intend it to do but given a lack of documentation (that I could find) - it may not, I will be happy to address issues identified in review :)

---

**Update**: As indicated by @felixoi, tracking has been [removed from Ore](https://github.com/SpongePowered/Ore/commit/76cab84ed76532146121a6d9b7a9809c7332bdb8) - though the `analytics.spongeproject.net` site continues to exist (I'm informed that this is only a temporary change, and it will be back with a new domain), so I believe this patch still has merit.