### PR TITLE
minimum fix to unbreak hpshop.hu original hp cartridge finder

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -5821,6 +5821,14 @@
       "hotwords.es"
     ]
   },
+  "HP_Partners": {
+    "properties": [
+      "hpshop.hu"
+    ],
+    "resources": [
+      "ext.hp.com"
+    ]
+  },
   "HP": {
     "properties": [
       "hp.com",


### PR DESCRIPTION
fix needed to unbreak ecommerce cartridge finder in firefox.  currently looks like this
![Screenshot (318)](https://user-images.githubusercontent.com/56973818/67515130-e9192080-f652-11e9-9a94-63a3744629f5.png)

It should look like this: 
![Screenshot (320)](https://user-images.githubusercontent.com/56973818/67515201-106fed80-f653-11e9-815f-958f758db075.png)

I believe this upload is the absolute minimum to make it work.
