### PR TITLE
Add nest.com to Google properties

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -5338,6 +5338,7 @@
       "google.vu",
       "google.ws",
       "ingress.com",
+      "nest.com",
       "panoramio.com",
       "youtube.com"
     ],


### PR DESCRIPTION
Nest is now owned/operated by Google. Recently the Nest site has been updated to allow integrated Google account sign-in/migration which may be blocked due to Nest and Google being treated as separate entities currently.

This change updates Google's entity list to reflect that nest.com is owned/operated as a top-level property of the same organization.