### PR TITLE
Remove Adform.com from resources in entities.json

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -407,7 +407,6 @@
       "adform.com"
     ],
     "resources": [
-      "adform.com",
       "adform.net",
       "adformdsp.net"
     ]


### PR DESCRIPTION
Adform.com was removed from resources.
Reason: 
Adform.com is not used as a tracking domain. Cookies on adform.com are used for internal system access.