### PR TITLE
Remove Adform.com domain from services

### DIFF
--- a/services.json
+++ b/services.json
@@ -293,7 +293,6 @@
       {
         "Adform": {
           "http://www.adform.com/": [
-            "adform.com",
             "adform.net",
             "adformdsp.net"
           ]


### PR DESCRIPTION
Adform.com domain is not used for ad tracking or ad delivery. Cookies on the domain are used for external users or applications logging in to internal systems.