### PR TITLE
Remove btstatic.com as tracker

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -2545,14 +2545,10 @@
   },
   "BrightTag": {
     "properties": [
-      "brighttag.com",
-      "btstatic.com",
-      "thebrighttag.com"
+      "brighttag.com"
     ],
     "resources": [
-      "brighttag.com",
-      "btstatic.com",
-      "thebrighttag.com"
+      "brighttag.com"
     ]
   },
   "Brilig": {

--- a/services.json
+++ b/services.json
@@ -1762,15 +1762,6 @@
         }
       },
       {
-        "BrightTag": {
-          "http://www.brighttag.com/": [
-            "brighttag.com",
-            "btstatic.com",
-            "thebrighttag.com"
-          ]
-        }
-      },
-      {
         "Brilig": {
           "http://www.brilig.com/": [
             "brilig.com"


### PR DESCRIPTION
**Removes btstatic.com as tracker** 
btstatic.com does not collect any kind of personal information that can track the user as an individual. Brighttag does not collect any "sensitive" or "special categories of personal data" as defined under European data protection laws. 
Brighttag is also CCPA and GDPR compliant and offer its users the possibility to opt out, removing all advertising data related to the user cookie.
The privacy policies can be found at https://www.signal.co/privacy-policy/