### PR TITLE
Add internalfb.com to Facebook properties

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -4554,6 +4554,7 @@
       "fbcdn.net",
       "friendfeed.com",
       "instagram.com",
+      "internalfb.com",
       "messenger.com",
       "oculus.com",
       "workplace.com"


### PR DESCRIPTION
Similar to the change in 9039222f75c893472409cf59388de84ee717e6d8. This domain is used internally at Facebook, so not having it on the entity list causes breakages similar to [bug 1590944](https://bugzilla.mozilla.org/show_bug.cgi?id=1590944)

Related to #104