### PR TITLE
Remove sendpulse.com

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -9667,14 +9667,6 @@
       "semasio.net"
     ]
   },
-  "SendPulse": {
-    "properties": [
-      "sendpulse.com"
-    ],
-    "resources": [
-      "sendpulse.com"
-    ]
-  },
   "Service4refresh": {
     "properties": [
       "service4refresh.info"

--- a/services.json
+++ b/services.json
@@ -9522,13 +9522,6 @@
         }
       },
       {
-        "SendPulse": {
-          "https://sendpulse.com/": [
-            "sendpulse.com"
-          ]
-        }
-      },
-      {
         "SessionCam": {
           "https://sessioncam.com/": [
             "sessioncam.com"


### PR DESCRIPTION
We are requesting to remove domain sendpulse.com from categories Analytics and Fingerprinting, because SendPulse is not creating user profiles using the collected data. We also do not give access to this data to any third party.

SendPulse is offering, among another services, an email subscription form builder. Our customers then place their forms on their websites. When a website visitor signs up using the form, their email is added to the mailing list in SendPulse.

We are using fingeerprint2 library to create a unique visitor ID so that we can offer our customer very basic stats about their subscription forms: form views; form bounces; form completions. This digital fingerprint and related data is stored in the in-memory storage (Redis) till a new 24-hour period starts, then the collected data is grouped. After the resulting stats about views, bounces and subscribes are stored, all details, including fingerprints, are permanently deleted. 
There is no additional processing of the collected data, user profiles are not created -- we are working with our customers' visitors. 

Our privacy policy is published at https://sendpulse.com/legal/pp