### PR TITLE
separate liveramp and rapleaf entities

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -6777,6 +6777,16 @@
       "liverail.com"
     ]
   },
+  "LiveRamp": {
+    "properties": [
+      "liveramp.com",
+      "rlcdn.com"
+    ],
+    "resources": [
+      "liveramp.com",
+      "rlcdn.com"
+    ]
+  },
   "LKQD": {
     "properties": [
       "lkqd.com",
@@ -9115,14 +9125,10 @@
   },
   "Rapleaf": {
     "properties": [
-      "liveramp.com",
       "rapleaf.com",
-      "rlcdn.com"
     ],
     "resources": [
-      "liveramp.com",
       "rapleaf.com",
-      "rlcdn.com"
     ]
   },
   "ReachLocal": {


### PR DESCRIPTION
**Summary**
This change creates a new entity -- `LiveRamp` -- and moves two of the domains which were misclassified as belonging to Rapleaf to the new LiveRamp entity, `rlcdn.com` and `liveramp.com`. 

**Basis**
LiveRamp and Rapleaf are discrete corporate entities and have been for 5+ years. `entities.json` should correctly describe domain ownership to the extent possible. 

**Supporting Evidence**
- `rapleaf.com` 301's to a subdomain of towerdata.com, the current corporate owner of Rapleaf:
```
< HTTP/1.1 301 Moved Permanently
< Date: Mon, 20 Jan 2020 00:24:02 GMT
< Location: https://intelligence.towerdata.com/
```
- [Wikipedia](https://en.wikipedia.org/wiki/RapLeaf#Controversy_and_backlash) indicates that _LiveRamp spun off the RapLeaf business and sold it to TowerData in 2013._
- [Coverage](https://adexchanger.com/data-exchanges/acxiom-to-buy-liveramp-for-310m/) in adexchanger states: _In 2011 the company developed the LiveRamp brand, which was later spun off from the RapLeaf corporate entity, the remnants of which were sold last October to TowerData._