### PR TITLE
Removes usocial.pro as fingerprinter

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -11170,14 +11170,6 @@
       "uservoice.com"
     ]
   },
-  "USocial": {
-    "properties": [
-      "usocial.pro"
-    ],
-    "resources": [
-      "usocial.pro"
-    ]
-  },
   "V12 Data": {
     "properties": [
       "v12group.com"

--- a/services.json
+++ b/services.json
@@ -10565,13 +10565,6 @@
         }
       },
       {
-        "USocial": {
-          "https://usocial.pro": [
-            "usocial.pro"
-          ]
-        }
-      },
-      {
         "Vendemore": {
           "https://vendemore.com/": [
             "vendemore.com"


### PR DESCRIPTION
We request that you remove the https://usocial.pro domain from the Analytics and Fingerprinting categories, since uSocial does not create user profiles using the collected data. Also, we do not provide access to any data collected by uSocial to third parties.

The uSocial service processes personal data exclusively in accordance with applicable legislation on the processing of personal data (including the standards established by GDPR) and does this on the basis of the personal data processing policy available at https://usocial.pro/agreement, according to paragraph 1.2 contained therein in our activities we are guided by the principle of “data minimization”, which means we collect personal information only to the extent sufficient for comfortable use of the service and for the collection purpose specified in this policy. Information is collected automatically at the time of registration and when using the service. An exhaustive list of purposes for collecting personal information is set forth in section 3 of the policy, in particular, personal information of users is utilized to provide access to the service, improve the service, provide technical support (feedback), create summary statistical information about the use of the service, send advertising newsletters (the user may refuse from receiving such newsletters unilaterally at any time), to prevent fraud and to comply with applicable legislation when the law requires it from us. In accordance with the terms of the agreement, we give users a guarantee that their personal information will not be used for purposes other than those mentioned above, including the sale/transfer of the information without an appropriate legal basis. We strive to ensure the user’s personal information is protected and preserved in accordance with the internal industry standards regardless of any lesser legal requirements as compared to those that may apply in the user’s jurisdiction.

The service is provided under a license under which the user is granted the right to use uSocial. uSocial does not process personal data of third parties who are not users of uSocial, so from the moment of obtaining the right to use the uSocial service, the user independently places the uSocial social buttons on their website and on their website determines the conditions for the collection and storage of personal data of persons who are their visitors and customers. uSocial uses the fingeerprint2 library to create a unique visitor identifier so that the uSocial user can get basic statistics about the subscription forms of visitors on their site. After automatically redirecting this information to the user, information about visitors who use social buttons is irrevocably destroyed and under no circumstances does uSocial have access to the specified information.

The use of the uSocial service by the user in violation of the license agreement and the uSocial data processing policy, including violation of the requirements of the applicable law, is the basis for restricting user access to the service. Based on the foregoing, we believe that the uSocial service does not violate the applicable law and your rules.