### PR TITLE
Request to remove poool.fr from Analytics and Fingerprinting categories

### DIFF
--- a/descriptions.md
+++ b/descriptions.md
@@ -75,7 +75,6 @@
 - [Paypal](#Paypal)
 - [PerimeterX](#PerimeterX)
 - [PinPoll](#PinPoll)
-- [Poool](#Poool)
 - [PPCProtect](#PPCProtect)
 - [PrismApp](#PrismApp)
 - [PrometheusIntelligenceTechnology](#PrometheusIntelligenceTechnology)
@@ -3925,62 +3924,6 @@ var Fingerprint2 = function e(t) {
                                 e.open("post", "https://pa.pinpoll.com/v1/"), e.withCredentials = !0, e.setRequestHeader("Content-Type", "application/json"), e.send(JSON.stringify(a))
                             }(), u = !0)
                         };
-
-```
-
-[Go back to top](#tracker-descriptions)
-
-## Poool
-This service has been classified as `Analytics` and `Fingerprinting` for the following reasons:
-### Technical Review
-Script: `https://assets.poool.fr/poool-identity.min.js`
-1. Script generates fingerprint by querying various device properties:
-```
-{
-                    key: "getScreenResolution",
-                    value: function() {
-                        return window.screen.width && window.screen.height ? window.screen.height > window.screen.width ? [window.screen.height, window.screen.width] : [window.screen.width, window.screen.height] : [0, 0]
-                    }
-                }, {
-                    key: "getCanvasSignature",
-                    value: function() {
-                        var t = $.getContext("2d"),
-                            e = "http://www.poool.fr";
-                        return t.clearRect(0, 0, $.width, $.height), t.textBaseline = "top", t.font = "14px 'Arial'", t.textBaseline = "alphabetic", t.fillStyle = "#f60", t.fillRect(125, 1, 62, 20), t.fillStyle = "#069", t.fillText(e, 2, 15), t.fillStyle = "rgba(102, 204, 0, 0.7)", t.fillText(e, 4, 17), $.toDataURL()
-                    }
-                }
-
-
-```
-2. Sends computed fingerprint back to server
-```
-{
-                    key: "headers",
-                    value: function(t) {
-                        var e = arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : {},
-                            n = {
-                                "Content-Type": "application/json"
-                            };
-                        if (!1 !== e.app && (n["Bundle-Identifier"] = G.a.get("app_id")), !1 !== e.fingerprint && (n.FTag = V.get()), !1 !== e.identity && (n.PTag = I.a.get("_poool") || G.a.get("$user_id") || ""), !1 !== e.additional && !0 === G.a.get("cookies_enabled")) {
-                            var r = window.xprops,
-                                o = r.windowWidth,
-                                i = r.windowHeight;
-                            n.Additional = "" + "screen=".concat(o, "x").concat(i, ";") + "locale=".concat(ot.a.getLocale(), ";") + "mobile=".concat(ot.a.isMobile())
-                        }
-                        if (!1 !== e.signature) try {
-                            var a = G.a.get("app_id"),
-                                s = z.a.jws.JWS.sign(null, {
-                                    alg: "HS256",
-                                    cty: "JWT"
-                                }, t, window.btoa(a));
-                            s && (n.Signature = window.btoa(s), n.Token = "v2")
-                        } catch (t) {
-                            N.a.error("Cannot sign request")
-                        }
-                        return n
-                    }
-                }
-
 
 ```
 

--- a/entities.json
+++ b/entities.json
@@ -8742,14 +8742,6 @@
       "pontiflex.com"
     ]
   },
-  "Poool": {
-    "properties": [
-      "poool.fr"
-    ],
-    "resources": [
-      "poool.fr"
-    ]
-  },
   "PopAds": {
     "properties": [
       "popads.net"

--- a/services.json
+++ b/services.json
@@ -9393,13 +9393,6 @@
         }
       },
       {
-        "Poool": {
-          "http://poool.fr/": [
-            "poool.fr"
-          ]
-        }
-      },
-      {
         "Pronunciator": {
           "http://www.pronunciator.com/": [
             "pronunciator.com",
@@ -10397,13 +10390,6 @@
         "Pixlee": {
           "https://www.pixlee.com/": [
             "pixlee.com"
-          ]
-        }
-      },
-      {
-        "Poool": {
-          "http://poool.fr/": [
-            "poool.fr"
           ]
         }
       },


### PR DESCRIPTION
Poool (www.poool.tech) is a dynamic paywall created to help journalism thrive and to allow readers to have easy access to quality articles. To be precise, we’re offering simple compensation choices to fairly unlock premium articles you want to read.
We used to generate fingerprints to count the number of free articles for a specific user on a publisher's website.
**We now removed any reference to fingerprints and only use a single first party cookie to identify user.**

Here is a quote from our privacy policy (https://poool.tech/en/privacy-policy):
Poool does not collect, retain, or share any data regarding a particular user's activity across multiple websites or applications. Poool does not collect or retain IP addresses or any information that would allow Poool to identify the same particular user on more than one website.

You can also read our cookie policy : https://poool.tech/en/cookie-policy

Thanks,
Ugo, CTO @p3ol