### PR TITLE
Removing DoubleVerify from the list following their recent Privacy Policy update

### DIFF
--- a/descriptions.md
+++ b/descriptions.md
@@ -38,7 +38,6 @@ The technical and policy review information below was recorded on the date obser
 - [CoinHive](#CoinHive)
 - [CoinPot](#CoinPot)
 - [CryptoLoot](#CryptoLoot)
-- [DoubleVerify](#DoubleVerify)
 - [ECSAnalytics](#ECSAnalytics)
 - [EroAdvertising](#EroAdvertising)
 - [EyeNewton](#EyeNewton)
@@ -2015,31 +2014,6 @@ function _0x45bcc2() {
 }
 ```
 [Go back to top](#tracker-descriptions)
-
-## DoubleVerify
-This service has been classified as `Analytics` and `Fingerprinting` for the following reasons:
-### Policy Review
-1. DoubleVerify’s privacy policy (`https://www.doubleverify.com/privacy/`) states they collect the following data:
-
-* "Mobile application, mobile device, and connected device data such as device identifiers, advertising IDs, application name, bundle IDs, application ID, store ID and other similar data."
-
-* "Device identification technology, which analyzes device parameters collected as described above, including IP address and browser header information, to probabilistically identify a particular device." 
-
-* "Clickstream data including URLs and other data regarding the websites on which a particular browser has viewed advertising impressions we are analyzing." 
-
-* "Clickstream data including mobile and connected device application identifier and other data regarding the mobile and connected device apps on which a particular user has viewed advertising impressions."
-
-* "Browser and computer environmental information necessary to determine the viewability of an advertisement, which includes information such as ad size, ad location in the browser viewport, size of the browser viewport, size of the display, application in focus, browser tab in focus, and other data."
-
-* "To deliver DoubleVerify Services, we use pixels and other similar technologies that can place a small piece of HTML code on a webpage to collect information about advertising impression opportunities and displayed ads or website traffic."
-
-2. DoubleVerify’s privacy policy states they may use the collected data as follows:
-
-* "We use the data we collect to provide DoubleVerify Services for any lawful purpose…"
-
-3. DoubleVerify’s privacy policy states they may disclose the collected data as follows:
-
-* "DoubleVerify shares information collected about online advertising impressions: (1) as is necessary to execute the DoubleVerify Services . . . (5) to a third party in the event of any reorganization, merger, sale, joint venture, assignment, transfer or other disposition of all or any portion of our business, assets or stock (including in connection with any bankruptcy or similar proceedings)."
 
 ## ECSAnalytics
 This service has been classified as `Analytics` and `Fingerprinting` for the following reasons:

--- a/entities.json
+++ b/entities.json
@@ -4001,14 +4001,6 @@
       "doublepositive.com"
     ]
   },
-  "DoubleVerify": {
-    "properties": [
-      "doubleverify.com"
-    ],
-    "resources": [
-      "doubleverify.com"
-    ]
-  },
   "Drawbridge": {
     "properties": [
       "drawbridge.com"

--- a/services.json
+++ b/services.json
@@ -8746,13 +8746,6 @@
         }
       },
       {
-        "DoubleVerify": {
-          "http://www.doubleverify.com/": [
-            "doubleverify.com"
-          ]
-        }
-      },
-      {
         "dwstat.com": {
           "http://www.dwstat.cn/": [
             "dwstat.cn"
@@ -10108,13 +10101,6 @@
         "dmpxs": {
           "http://bob.dmpxs.com": [
             "dmpxs.com"
-          ]
-        }
-      },
-      {
-        "DoubleVerify": {
-          "http://www.doubleverify.com/": [
-            "doubleverify.com"
           ]
         }
       },


### PR DESCRIPTION

DoubleVerify eliminated the code previously flagged by Disconnect and addressed all privacy policy issues that Disconnect cited. 

The ongoing email thread with Jon Norris and Casey Oppenheim contains more details about the actions taken. 
