### PR TITLE
Remove OpenX as a Fingerprinter.

### DIFF
--- a/services.json
+++ b/services.json
@@ -10416,13 +10416,6 @@
         }
       },
       {
-        "OpenX": {
-          "http://openx.com/": [
-            "openx.net"
-          ]
-        }
-      },
-      {
         "Opolen": {
           "https://opolen.com.br": [
             "opolen.com.br"


### PR DESCRIPTION
Addresses #137 by removing OpenX from the fingerprinting category.