### PR TITLE
Remove Akamai mPulse

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -1526,7 +1526,6 @@
       "abmr.net",
       "akamai.com",
       "edgesuite.net",
-      "go-mpulse.net",
       "imiclk.com"
     ]
   },

--- a/services.json
+++ b/services.json
@@ -8619,13 +8619,6 @@
         }
       },
       {
-        "Akamai": {
-          "http://www.akamai.com/": [
-            "go-mpulse.net"
-          ]
-        }
-      },
-      {
         "Amadesa": {
           "http://www.amadesa.com/": [
             "amadesa.com"


### PR DESCRIPTION
Hello!

[mPulse](https://www.akamai.com/us/en/products/performance/mpulse-real-user-monitoring.jsp) is a performance monitoring product from [Akamai](https://www.akamai.com/).

mPulse uses the open-source Real User Monitoring (RUM) library [Boomerang](https://github.com/akamai/boomerang) to measure the performance of visitors to our customer's website.  mPulse's customers use these metrics to measure, monitor and improve the performance and user-experience of their visitors.

mPulse and Boomerang do not track visitors across multiple customers.  The data in the mPulse beacon is available only to that customer.  We do not have any cross-site tracking IDs or cookies on the `go-mpulse.net` or `akstat.io` domains (used for the JavaScript/configuration and beacons respectively).  Our customers may enable a first-party cookie (called `RT`) on their own domain that is short-lived and used for tracking individual user sessions on that domain only.  We do not store or share Personally Identifiably Information (PII) of our customer's visitors.

Here are some links to our Privacy Policies:

* [mPulse - Compliance with Global Data Protection Laws](https://www.akamai.com/us/en/multimedia/documents/white-paper/mpulse-compliance-with-global-data-protection-laws.pdf)
* [Akamai Privacy Policies](https://www.akamai.com/us/en/privacy-policies/)

Please let us know if you have any questions or need clarifications.