### PR TITLE
Add e.gg to list of Facebook properties.

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -4545,6 +4545,7 @@
   "Facebook": {
     "properties": [
       "atlassolutions.com",
+      "e.gg",
       "facebook.com",
       "facebook.de",
       "facebook.fr",


### PR DESCRIPTION
Similar to changes in #104 and #127, this adds a first-party Facebook property.