### PR TITLE
Add marktplaats.nl, 2dehands.be and 2ememain.be as eBay properties

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -4185,6 +4185,8 @@
     },
     "eBay": {
       "properties": [
+        "2dehands.be",
+        "2ememain.be",
         "ebay-kleinanzeigen.de",
         "ebay.at",
         "ebay.ba",
@@ -4209,7 +4211,8 @@
         "ebay.in",
         "ebay.it",
         "ebay.nl",
-        "ebay.pl"
+        "ebay.pl",
+        "marktplaats.nl"
       ],
       "resources": [
         "ebay.com",


### PR DESCRIPTION
Marktplaats.nl, 2dehands.be and 2ememain.be are eBay properties in the Netherlands and Belgium. They use ebayimg.com to host images, which are now blocked in Firefox 79.0 because of a plugin. This PR should hopefully fix that