### PR TITLE
Add oversightboard.com to Facebook properties

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -4691,6 +4691,7 @@
         "internalfb.com",
         "messenger.com",
         "oculus.com",
+        "oversightboard.com",
         "whatsapp.com",
         "workplace.com"
       ],


### PR DESCRIPTION
Similar to the change in [127](https://github.com/disconnectme/disconnect-tracking-protection/pull/127). Facebook own this domain, so not having it on the entity list causes breakages similar to [bug 1675275](https://bugzilla.mozilla.org/show_bug.cgi?id=1675275)
