### PR TITLE
Add dnacdn.net to Criteo services

### DIFF
--- a/services.json
+++ b/services.json
@@ -2413,7 +2413,8 @@
             "criteo.net",
             "hlserve.com",
             "hooklogic.com",
-            "storetail.io"
+            "storetail.io",
+            "dnacdn.net"
           ]
         }
       },


### PR DESCRIPTION
```
$ host dnacdn.net
dnacdn.net has address 178.250.0.157
$ whois 178.250.0.157
% This is the RIPE Database query service.
...
netname:        CRITEO-EUROPE-INFRA
descr:          Criteo Europe Infrastructures
```