### PR TITLE
adsty.com is puton sale by domain sharks

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -1118,11 +1118,9 @@
     },
     "Adsty": {
       "properties": [
-        "adsty.com",
         "adx1.com"
       ],
       "resources": [
-        "adsty.com",
         "adx1.com"
       ]
     },


### PR DESCRIPTION
adsty.com is no longer an adserving domain, but hijacked by hugedomains `https://www.hugedomains.com/domain_profile.cfm?d=adsty&e=com`

![image](https://user-images.githubusercontent.com/44526987/121746603-68988380-cb06-11eb-984b-987cb2e27158.png)

