### PR TITLE
Add Built In properties to entity list (#1)

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -2637,6 +2637,30 @@
         "bufferapp.com"
       ]
     },
+    "BuiltIn": {
+      "properties": [
+        "builtin.com",
+        "builtinaustin.com",
+        "builtinboston.com",
+        "builtinchicago.org",
+        "builtincolorado.com",
+        "builtinla.com",
+        "builtinnyc.com",
+        "builtinseattle.com",
+        "builtinsf.com"
+      ],
+      "resources": [
+        "builtin.com",
+        "builtinaustin.com",
+        "builtinboston.com",
+        "builtinchicago.org",
+        "builtincolorado.com",
+        "builtinla.com",
+        "builtinnyc.com",
+        "builtinseattle.com",
+        "builtinsf.com"
+      ]
+    },
     "Bunchball": {
       "properties": [
         "bunchball.com"


### PR DESCRIPTION
This adds all of Built In's domains to the entity list so that we can share 1st party cookies as 1st party cookies 🙂 