### PR TITLE
Add Zeta Global/Boomtrain to trackers

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -13021,6 +13021,14 @@
         "zetaemailsolutions.com"
       ]
     },
+    "Zeta Global": {
+      "properties": [
+        "zetaglobal.com",
+      ],
+      "resources": [
+        "boomtrain.com"
+      ]
+    },
     "Zip": {
       "properties": [
         "zip.co"


### PR DESCRIPTION
boomtrain.com redirects to zetaglobal.com

I'm not sure how you would want to categorize ZetaGlobal in services.json so I didn't make an accompanying pull requests there