### PR TITLE
Fix: Update Wrongly Labeled Domain

### DIFF
--- a/services.json
+++ b/services.json
@@ -1831,7 +1831,6 @@
             "adknowledge.com",
             "adparlor.com",
             "bidsystem.com",
-            "cubics.com",
             "lookery.com"
           ]
         }


### PR DESCRIPTION
Submitting a PR to remove a domain that was used for ad-tracking 10 years ago. The domain was parked and is not used for anything ad-related any longer, kindly remove it from the block lists (because Firefox keeps blocking cross-origin requests to it, wrongly labeling it as an ad tracker).